### PR TITLE
Fixes #4

### DIFF
--- a/commands/coldbox/create/module.cfc
+++ b/commands/coldbox/create/module.cfc
@@ -14,7 +14,7 @@ component extends="coldbox-cli.models.BaseCommand" {
 	 * @author         Whoever wrote this module
 	 * @authorURL      The author's URL
 	 * @description    The description for this module
-	 * @version        The semantic version number: major.minior.patch
+	 * @version        The semantic version number: major.minor.patch
 	 * @cfmapping      A CF app mapping to create that points to the root of this module
 	 * @modelNamespace The namespace to use when mapping the models in this module
 	 * @dependencies   The list of dependencies for this module


### PR DESCRIPTION
Fix typo in run() method javadoc heading

# Description

Fixed typo in the javadoc metadata for the run() method (on the version option).

**Please note that all PRs must have tests attached to them**

IMPORTANT: Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

## Issues

[https://github.com/ColdBox/coldbox-cli/issues/4]

## Type of change

- [X] Bug Fix

## Checklist

- [ ] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
None of the above apply
