### PR TITLE
Respect CFML if Boxlang is set to false

### DIFF
--- a/commands/coldbox/create/app-wizard.cfc
+++ b/commands/coldbox/create/app-wizard.cfc
@@ -44,9 +44,11 @@ component extends="app" aliases="" {
 		// Language Selection
 		if ( confirm( "Is this a BoxLang project? [y/n]" ) ) {
 			arguments.boxlang = true;
+			arguments.cfml = false;
 			boxlangWizard( args = arguments );
 		} else {
 			arguments.boxlang = false;
+			arguments.cfml = true;
 			cfmlWizard( args = arguments );
 		}
 
@@ -110,7 +112,7 @@ component extends="app" aliases="" {
 				"------------------------------------------------------------------------------------------"
 			);
 
-			arguments.skeleton = multiselect( "Which template would you like to use?" )
+			args.skeleton = multiselect( "Which template would you like to use?" )
 				.options( [
 					{
 						accessKey : 1,
@@ -137,7 +139,7 @@ component extends="app" aliases="" {
 				"------------------------------------------------------------------------------------------"
 			);
 
-			arguments.skeleton = multiselect( "Which template would you like to use?" )
+			args.skeleton = multiselect( "Which template would you like to use?" )
 				.options( [
 					{
 						accessKey : 1,


### PR DESCRIPTION
# Description

When trying to create a quick coldbox api for CFML using the `coldbox create app --wizard`, even though I answered "no" to the "Is this a Boxlang question", it still uses the coldbox-boxlang template and gives me all the bx files.  It also says "Language set to Boxlang"

## Issues

[Boxlang template is used even if Boxlang is set to false](https://github.com/ColdBox/coldbox-cli/issues/31)

## Type of change

- Bug Fix