### PR TITLE
Conflict fix: Rename update alias to be specific to coldbox ai

### DIFF
--- a/commands/coldbox/ai/refresh.cfc
+++ b/commands/coldbox/ai/refresh.cfc
@@ -6,7 +6,7 @@
  * coldbox ai refresh
  * coldbox ai update
  */
-component extends="coldbox-cli.models.BaseAICommand" aliases="update" {
+component extends="coldbox-cli.models.BaseAICommand" aliases="coldbox ai update" {
 
 	/**
 	 * Run the command


### PR DESCRIPTION
# Description

This is a simple bug fix to change the alias for coldbox ai refresh from the current `update` (which conflicts with CommandBox's update) to `coldbox ai update` which is what I believe @lmajano intended as an alias for coldbox ai refresh.

## Type of change

- [x] Bug Fix