### PR TITLE
Refactor serverInfo retrieval in reinit/fwreinit command

### DIFF
--- a/commands/coldbox/reinit.cfc
+++ b/commands/coldbox/reinit.cfc
@@ -26,7 +26,13 @@ component aliases="fwreinit" {
 		name     = getDefaultServerName(),
 		showUrl  = true
 	){
-		var serverInfo = serverService.getServerInfoByDiscovery( name = arguments.name );
+		var serverInfo = serverService.resolveServerDetails( { name: arguments.name, directory: getCWD() } ).serverInfo;
+
+		if ( serverInfo.port EQ 0 ) {
+			//resolveServerDetails() returns port 0 by default 
+			//still works to initialize the coldbox but commandbox shows Hitting... 127.0.0.1:0/?fwreinit=1
+			serverInfo.port = 80;
+		}
 
 		if ( !structCount( serverInfo ) ) {
 			print.boldRedLine(

--- a/commands/coldbox/reinit.cfc
+++ b/commands/coldbox/reinit.cfc
@@ -28,18 +28,12 @@ component aliases="fwreinit" {
 	){
 		var serverInfo = serverService.resolveServerDetails( { name: arguments.name, directory: getCWD() } ).serverInfo;
 
-		if ( serverInfo.port EQ 0 ) {
-			//resolveServerDetails() returns port 0 by default 
-			//still works to initialize the coldbox but commandbox shows Hitting... 127.0.0.1:0/?fwreinit=1
-			serverInfo.port = 80;
-		}
-
 		if ( !structCount( serverInfo ) ) {
 			print.boldRedLine(
 				"No server configurations found for '#getCWD()#' and '#arguments.name#', so have no clue what to reinit buddy!"
 			);
 		} else {
-			var thisURL = "#serverInfo.host#:#serverInfo.port#/?fwreinit=#arguments.password#";
+			var thisURL = "#serverInfo.defaultBaseURL#/?fwreinit=#arguments.password#";
 			if ( arguments.showUrl ) {
 				print.greenLine( "Hitting... #thisURL#" );
 			}


### PR DESCRIPTION
Updated serverInfo retrieval to use resolveServerDetails and handle default port.

getServerInfoByDiscovery() is not correctly resolving in BoxLang Apps. 

Switching to resolveServerDetails() which is the same resolver for server info, status commands

I tested it on Lucee and a BoxLang app. 

I wish i could be more helpful but respectfully, I have to move on and will pass on creating a test for this.
